### PR TITLE
add options page with toggle to disable jk escape behaviour

### DIFF
--- a/contentscript_idle.js
+++ b/contentscript_idle.js
@@ -1,16 +1,47 @@
+// Define an array of supported option keys, which we'll use to fetch the
+// options from Chrome storage.
+const SUPPORTED_OPTIONS = ['jkToEsc'];
+// API that the content script uses to notify page scripts of option changes.
+// The function dispatches the custom event defined above, passing the updated
+// options as the event detail.
+function sendOptions(options) {
+    window.dispatchEvent(
+        new CustomEvent('optionChangeEvent', { detail: { options }}),
+    );
+}
+// Register an event listener for changes to the extension's options in Chrome
+// storage. When the options change, we extract the updated values and send them
+// to the page scripts via a custom event.
+chrome.storage.onChanged.addListener(function(changes, namespace) {
+    sendOptions(
+        Object.fromEntries(
+            Object.entries(changes).map(([k,v]) => [k, v.newValue])
+        )
+    )
+});
 
-var scripts = [ 
+var scripts = [
     "keybindings.js",
     "transparentKeybindings.js",
-    "vimflowy.js"
+    "vimflowy.js",
+    "options.js"
     ];
 
-for (var i=0; i < scripts.length; i++) 
+let scriptsLoaded = 0;
+for (var i=0; i < scripts.length; i++)
 {
     var s = document.createElement('script');
     s.src = chrome.extension.getURL(scripts[i]);
     (document.head||document.documentElement).appendChild(s);
     s.onload = function() {
+        scriptsLoaded += 1;
+        // Once all scripts have loaded, fetch the extension's options from
+        // Chrome storage and send them to the page scripts via a custom event.
+        if (scriptsLoaded == scripts.length) {
+            chrome.storage.sync.get(SUPPORTED_OPTIONS, (options) => {
+                sendOptions(options);
+            });
+        }
         this.parentNode.removeChild(this);
     };
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,26 +5,26 @@
   "version": "0.0.4.9",
   "manifest_version": 2,
   "icons": { "48": "icon48.png", "128": "icon128.png" },
-  "content_scripts": 
+  "content_scripts":
   [
     {
       "matches": ["https://workflowy.com/*", "https://*.workflowy.com/*"],
       "run_at": "document_start",
-      "js": 
+      "js":
       [
         "contentscript_start.js"
       ]
-    }, 
+    },
     {
       "matches": ["https://workflowy.com/*", "https://*.workflowy.com/*"],
       "run_at": "document_idle",
-      "js": 
+      "js":
       [
         "contentscript_idle.js"
       ]
     }
   ],
-  "web_accessible_resources": [ 
+  "web_accessible_resources": [
     "state.js",
     "TimeTagCounter.js",
     "easyMotion.js",
@@ -32,10 +32,13 @@
     "vimflowyFunctionLibrary.js",
     "keybindings.js",
     "transparentKeybindings.js",
-    "vimflowy.js"
+    "vimflowy.js",
+    "options.js"
   ],
   "permissions": [
     "https://workflowy.com/*",
-    "https://*.workflowy.com/*"
-	]
+    "https://*.workflowy.com/*",
+    "storage"
+	],
+  "options_page": "options.html"
 }

--- a/optionPage.js
+++ b/optionPage.js
@@ -1,0 +1,35 @@
+const DEFAULTS = {
+  jkToEsc: true,
+}
+
+// Saves options to chrome.storage
+function saveOptions() {
+  const elemValues = getElementValues();
+  chrome.storage.sync.set(elemValues);
+}
+
+// Restores state using the preferences stored in chrome.storage.
+function restoreOptions() {
+  chrome.storage.sync.get(DEFAULTS, function(items) {
+    setElementValues(items)
+  });
+}
+
+function getElementValues() {
+  return {
+    jkToEsc: document.getElementById('jkToEsc').checked,
+  };
+}
+
+function setElementValues(items) {
+  document.getElementById('jkToEsc').checked = items.jkToEsc;
+}
+
+function setElementValuesToDefaults() {
+  setElementValues(DEFAULTS);
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('save').addEventListener('click', saveOptions);
+document.getElementById('restore').addEventListener('click',
+  setElementValuesToDefaults);

--- a/options.html
+++ b/options.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Options</title>
+    <style>
+      body {
+        font-size: 14px;
+        background-color: #fff;
+        color: var(--fg);
+        width: min(100% - 2rem, 70rem);
+        margin-inline: auto;
+        font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
+      }
+      h1 {
+        display: flex;
+        align-items: center;
+      }
+      h3 {
+        background-color: rgba(0, 0, 0, 0.05);
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 100%;
+        font-weight: normal;
+    }
+    img {
+        margin-right: 12px;
+    }
+    .box-1 {
+        display: grid;
+        align-items: center;
+        grid-template-columns: 24px 1fr;
+        grid-gap: 5px;
+    }
+    .save-box {
+        margin-top: 10px;
+    }
+    </style>
+  </head>
+  <body>
+    <h1><img src="icon48.png"/>Vimflowy options</h1>
+    <h3>Mapping customization</h3>
+    <div class="box-1">
+        <input type="checkbox" id="jkToEsc">
+        <label for="jkToEsc">Map jk to Esc</label>
+    </div>
+    <div class="save-box">
+        <button id="save">Save Options</button>
+        <button id="restore">Restore Defaults</button>
+    </div>
+    <script src="optionPage.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,21 @@
+/**
+ * We store the extension's options in Chrome storage because it provides a
+ * way to persistently store data across browser sessions. However, only content
+ * scripts have access to the Chrome storage API, so we use a custom event to
+ * make the options accessible to the page scripts.
+ */
+
+// Initialize an object to store the extension's options and assign default
+// values.
+const OPTIONS = {
+  'jkToEsc': true,
+};
+// Register an event listener for a custom event that content scripts will
+// dispatch when the options change. When the event is received, we update the
+// OPTIONS object with the new values.
+window.addEventListener('optionChangeEvent', event => {
+	for (const [key, value] of Object.entries(event.detail.options)) {
+		OPTIONS[key] = value;
+	}
+});
+

--- a/transparentKeybindings.js
+++ b/transparentKeybindings.js
@@ -588,6 +588,9 @@ const transparentActionMap =
 	  },
 	  'jk': e => 
 	  {
+		if (!OPTIONS.jkToEsc) {
+			return;
+		}
 	    // guard against accidently pressing jk while in the menu 
 		const focusedItem = WF.focusedItem();
 		if(!focusedItem)


### PR DESCRIPTION
This adds a simple options page. It's currently limited to controlling whether jk maps to Esc in normal mode.

<img width="1920" alt="Screenshot 2023-04-21 at 22 18 59" src="https://user-images.githubusercontent.com/1927048/233727321-cf203e7f-0cfc-4749-8cac-c34dce666d06.png">

Options are stored in Chrome storage. Only content scripts have access to the Chrome storage API. To pass options from contentscript_idle to our page scipts, we use a custom event. 

A cleaner solution would be to refactor the javascript to ES6 modules and use a bundler to pack everything into a single content script. But that would be significantly more work. This works for now.

Fixes issue #28 .